### PR TITLE
chore: defer stylesheet loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,13 +7,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Stars and Stripes Automotive, LLC</title>
 
-  <link
-    rel="preload"
-    href="/src/index.scss"
-    as="style"
-    onload="this.onload=null;this.rel='stylesheet'"
-  />
-  <noscript><link rel="stylesheet" href="/src/index.scss" /></noscript>
 
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/src/components/Sliders/HeroSlider.jsx
+++ b/src/components/Sliders/HeroSlider.jsx
@@ -1,9 +1,9 @@
-import React, { useRef } from "react";
+import React, { useRef, useEffect } from "react";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Parallax, Pagination } from "swiper/modules";
-import "swiper/css";
-import "swiper/css/pagination";
-import "swiper/css/parallax";
+import swiperCss from "swiper/css?url";
+import paginationCss from "swiper/css/pagination?url";
+import parallaxCss from "swiper/css/parallax?url";
 import { ButtonCommon } from "../Button/Button";
 import { Link } from "react-router-dom";
 
@@ -44,6 +44,19 @@ const sliderData = [
 
 const HeroSlider = () => {
   const swiperRef = useRef(null);
+  useEffect(() => {
+    [swiperCss, paginationCss, parallaxCss].forEach((href) => {
+      const link = document.createElement("link");
+      link.rel = "preload";
+      link.as = "style";
+      link.href = href;
+      link.onload = () => {
+        link.onload = null;
+        link.rel = "stylesheet";
+      };
+      document.head.appendChild(link);
+    });
+  }, []);
   return (
     <section className="ak-slider ak-slider-hero-1">
       <Swiper

--- a/src/components/Testimonial/Testimonial.jsx
+++ b/src/components/Testimonial/Testimonial.jsx
@@ -1,8 +1,8 @@
-import React, { useRef } from "react";
+import React, { useRef, useEffect } from "react";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { EffectFade } from "swiper/modules";
-import "swiper/css";
-import "swiper/css/effect-fade";
+import swiperCss from "swiper/css?url";
+import effectFadeCss from "swiper/css/effect-fade?url";
 import SectionHeading from "../SectionHeading/SectionHeading";
 
 import testimaonialBgImg from "/assets/img/bg/testimaonial-img-bg.png";
@@ -26,6 +26,19 @@ const sliderData = [
 
 const Testimonial = () => {
   const swiperRef = useRef(null);
+  useEffect(() => {
+    [swiperCss, effectFadeCss].forEach((href) => {
+      const link = document.createElement("link");
+      link.rel = "preload";
+      link.as = "style";
+      link.href = href;
+      link.onload = () => {
+        link.onload = null;
+        link.rel = "stylesheet";
+      };
+      document.head.appendChild(link);
+    });
+  }, []);
   return (
     <div className="container">
       <div className="ak-height-125 ak-height-lg-80"></div>

--- a/src/components/TrustedClient/TrustedClient.jsx
+++ b/src/components/TrustedClient/TrustedClient.jsx
@@ -1,6 +1,6 @@
-import React, { useRef } from "react";
+import React, { useRef, useEffect } from "react";
 import { Swiper, SwiperSlide } from "swiper/react";
-import "swiper/css";
+import swiperCss from "swiper/css?url";
 
 const imgList = [
   "/assets/img/client/trusted-client_1.png",
@@ -17,6 +17,17 @@ const imgList = [
 
 const TrustedClient = () => {
   const swiperRef = useRef(null);
+  useEffect(() => {
+    const link = document.createElement("link");
+    link.rel = "preload";
+    link.as = "style";
+    link.href = swiperCss;
+    link.onload = () => {
+      link.onload = null;
+      link.rel = "stylesheet";
+    };
+    document.head.appendChild(link);
+  }, []);
   return (
     <div className="container">
       <div className="ak-height-125 ak-height-lg-80"></div>

--- a/src/components/VideoPopUp/VideoButton.jsx
+++ b/src/components/VideoPopUp/VideoButton.jsx
@@ -1,9 +1,21 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import ModalVideo from "react-modal-video";
-import "react-modal-video/css/modal-video.css";
+import modalCss from "react-modal-video/css/modal-video.css?url";
 
 export default function VideoButton({ videoId }) {
   const [isOpen, setOpen] = useState(false);
+
+  useEffect(() => {
+    const link = document.createElement("link");
+    link.rel = "preload";
+    link.as = "style";
+    link.href = modalCss;
+    link.onload = () => {
+      link.onload = null;
+      link.rel = "stylesheet";
+    };
+    document.head.appendChild(link);
+  }, []);
   return (
     <div className="video-section">
       <ModalVideo

--- a/src/components/VideoPopUp/Videos.jsx
+++ b/src/components/VideoPopUp/Videos.jsx
@@ -1,11 +1,23 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import ModalVideo from "react-modal-video";
-import "react-modal-video/css/modal-video.css";
+import modalCss from "react-modal-video/css/modal-video.css?url";
 
 import aboutVideoBg from "/assets/img/bg/car_video_bg.jpg";
 
 const Videos = ({ videoId }) => {
   const [isOpen, setOpen] = useState(false);
+
+  useEffect(() => {
+    const link = document.createElement("link");
+    link.rel = "preload";
+    link.as = "style";
+    link.href = modalCss;
+    link.onload = () => {
+      link.onload = null;
+      link.rel = "stylesheet";
+    };
+    document.head.appendChild(link);
+  }, []);
   return (
     <>
       <div className="ak-height-150 ak-height-lg-60"></div>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,7 +2,18 @@ import React from "react";
 import { BrowserRouter } from "react-router-dom";
 import ReactDOM from "react-dom/client";
 import App from "./App.jsx";
+import cssHref from "./index.scss?url";
 
+// defer stylesheet loading to avoid render-blocking
+const link = document.createElement("link");
+link.rel = "preload";
+link.as = "style";
+link.href = cssHref;
+link.onload = () => {
+  link.onload = null;
+  link.rel = "stylesheet";
+};
+document.head.appendChild(link);
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>

--- a/src/pages/Gallery.jsx
+++ b/src/pages/Gallery.jsx
@@ -1,15 +1,30 @@
 import { Link } from "react-router-dom";
+import { useEffect } from "react";
 
 import LightGallery from "lightgallery/react";
 import lgThumbnail from "lightgallery/plugins/thumbnail";
-import "lightgallery/css/lightgallery.css";
-import "lightgallery/css/lg-thumbnail.css";
+import lightGalleryCss from "lightgallery/css/lightgallery.css?url";
+import lgThumbnailCss from "lightgallery/css/lg-thumbnail.css?url";
 import CommonPageHero from "../components/CommonPageHero/CommonPageHero";
 import SEO from "../components/SEO";
 
 import imageData from "../dataJson/galleryImgData.json";
 
 const Gallery = () => {
+  useEffect(() => {
+    [lightGalleryCss, lgThumbnailCss].forEach((href) => {
+      const link = document.createElement("link");
+      link.rel = "preload";
+      link.as = "style";
+      link.href = href;
+      link.onload = () => {
+        link.onload = null;
+        link.rel = "stylesheet";
+      };
+      document.head.appendChild(link);
+    });
+  }, []);
+
   return (
     <>
         <SEO


### PR DESCRIPTION
## Summary
- load main stylesheet via preload to remove render-blocking CSS
- defer third-party CSS (LightGallery, Swiper, modal video) until components mount

## Testing
- `npm run build`
- `npm run lint` *(fails: 'React' is defined but never used, missing prop validation, and other pre-existing errors)*

------
https://chatgpt.com/codex/tasks/task_e_68afa844835c832eb7d89abae9e8524a